### PR TITLE
bootloader-emmc-linux: remove license.txt from install list

### DIFF
--- a/recipes-bsp/bootloader/bootloader-emmc-linux_17.09.bb
+++ b/recipes-bsp/bootloader/bootloader-emmc-linux_17.09.bb
@@ -25,7 +25,7 @@ do_compile() {
 }
 do_install() {
     install -d ${D}${libdir}/${PN}
-    for f in NON-HLOS.bin hyp.mbn rpm.mbn tz.mbn sbl1.mbn license.txt; do
+    for f in NON-HLOS.bin hyp.mbn rpm.mbn tz.mbn sbl1.mbn LICENSE; do
 	install -m 0644 $f ${D}${libdir}/${PN}/
     done
     install -m 0644 emmc-partitions.txt ${D}${libdir}/${PN}/partitions.txt


### PR DESCRIPTION
The archive file dragonboard410c_bootloader_emmc_linux-88.zip
does not have license.txt file